### PR TITLE
Add toString to CalendarMetrics, fixes #3

### DIFF
--- a/src/main/java/org/dmfs/rfc5545/DateTime.java
+++ b/src/main/java/org/dmfs/rfc5545/DateTime.java
@@ -66,7 +66,7 @@ public final class DateTime
     /**
      * The packed instance of this {@link DateTime}. This will be {@link Long#MAX_VALUE} if it has not been calculated yet.
      *
-     * @see Instance.
+     * @see Instance
      */
     private long mInstance = Long.MAX_VALUE;
     /**

--- a/src/main/java/org/dmfs/rfc5545/calendarmetrics/CalendarMetrics.java
+++ b/src/main/java/org/dmfs/rfc5545/calendarmetrics/CalendarMetrics.java
@@ -53,11 +53,15 @@ public abstract class CalendarMetrics
      */
     public final int minDaysInFirstWeek;
 
-    public CalendarMetrics(Weekday weekStart, int minDaysInFirstWeek)
+    private final String mName;
+
+
+    public CalendarMetrics(String name, Weekday weekStart, int minDaysInFirstWeek)
     {
         this.weekStart = weekStart;
         this.weekStartInt = weekStart.ordinal();
         this.minDaysInFirstWeek = minDaysInFirstWeek;
+        this.mName = name;
     }
 
 
@@ -227,7 +231,6 @@ public abstract class CalendarMetrics
      */
     public abstract int getMaxMonthDayNum();
 
-
     /**
      * Returns the largest year day number that the current calendar supports.
      *
@@ -235,14 +238,12 @@ public abstract class CalendarMetrics
      */
     public abstract int getMaxYearDayNum();
 
-
     /**
      * Returns the largest week number that the current calendar supports.
      *
      * @return The maximum ISO week number in this calendar scale.
      */
     public abstract int getMaxWeekNoNum();
-
 
     /**
      * Get the number of days in a specific packed month.
@@ -256,7 +257,6 @@ public abstract class CalendarMetrics
      */
     public abstract int getDaysPerPackedMonth(int year, int packedMonth);
 
-
     /**
      * Determines the month of a given day of year.
      *
@@ -269,7 +269,6 @@ public abstract class CalendarMetrics
      */
     public abstract int getPackedMonthOfYearDay(int year, int yearDay);
 
-
     /**
      * Determines the day of month for a given day of year.
      *
@@ -281,7 +280,6 @@ public abstract class CalendarMetrics
      * @return the month day.
      */
     public abstract int getDayOfMonthOfYearDay(int year, int yearDay);
-
 
     /**
      * Determines the month and day for a given day of year. The result contains both, packed month and day in a single integer. To split the values use {@link
@@ -302,7 +300,6 @@ public abstract class CalendarMetrics
      */
     public abstract int getMonthAndDayOfYearDay(int year, int yearDay);
 
-
     /**
      * Get the number of days preceding the given month in the given year.
      *
@@ -315,7 +312,6 @@ public abstract class CalendarMetrics
      */
     public abstract int getYearDaysForPackedMonth(int year, int packedMonth);
 
-
     /**
      * Get the number of months in the given year.
      *
@@ -326,7 +322,6 @@ public abstract class CalendarMetrics
      */
     public abstract int getMonthsPerYear(int year);
 
-
     /**
      * Get the number of days in the given year.
      *
@@ -336,7 +331,6 @@ public abstract class CalendarMetrics
      * @return The number of days in that year.
      */
     public abstract int getDaysPerYear(int year);
-
 
     /**
      * Get the number of ISO weeks in the given year.
@@ -438,7 +432,6 @@ public abstract class CalendarMetrics
      */
     public abstract int getDayOfYear(int year, int packedMonth, int dayOfMonth);
 
-
     /**
      * Get the day of the year for the specified ISO week date, see <a href="http://en.wikipedia.org/wiki/ISO_week_date">ISO week date</a>
      * <p>
@@ -457,7 +450,6 @@ public abstract class CalendarMetrics
      */
     public abstract int getYearDayOfIsoYear(int year, int weekOfYear, int dayOfWeek);
 
-
     /**
      * Get the weekday of the first day (which is January the 1st in a Gregorian Calendar) in the given year.
      *
@@ -467,7 +459,6 @@ public abstract class CalendarMetrics
      * @return The weekday number.
      */
     public abstract int getWeekDayOfFirstYearDay(int year);
-
 
     /**
      * Get the day of year of the start of the first week in a year. Note this method returns values below 1 if the start of the week is in the previous year.
@@ -479,7 +470,6 @@ public abstract class CalendarMetrics
      * @return The day of year.
      */
     public abstract int getYearDayOfFirstWeekStart(int year);
-
 
     /**
      * Get the day of year of the start of the given week in a year. Note this method returns values below 1 if the start of the week is in the previous year.
@@ -535,7 +525,6 @@ public abstract class CalendarMetrics
      * @return The milliseconds since the epoch.
      */
     public abstract long toMillis(TimeZone timeZone, int year, int packedMonth, int dayOfMonth, int hours, int minutes, int seconds, int millis);
-
 
     /**
      * Converts a timestamp to an instance in the given {@link TimeZone}.
@@ -628,7 +617,6 @@ public abstract class CalendarMetrics
      */
     public abstract long nextMonth(long instance, int n);
 
-
     /**
      * Moves the given instance backward by one month. In many cases this is faster than {@link #prevMonth(long, int)} with <code>n = 1</code>.
      *
@@ -638,7 +626,6 @@ public abstract class CalendarMetrics
      * @return A new instance.
      */
     public abstract long prevMonth(long instance);
-
 
     /**
      * Moves the given instance backward by one or more months.
@@ -652,7 +639,6 @@ public abstract class CalendarMetrics
      */
     public abstract long prevMonth(long instance, int n);
 
-
     /**
      * Moves the given instance forward to the next (existing day).
      *
@@ -662,7 +648,6 @@ public abstract class CalendarMetrics
      * @return A new instance.
      */
     public abstract long nextDay(long instance);
-
 
     /**
      * Moves the given instance forward by one or more days.
@@ -676,7 +661,6 @@ public abstract class CalendarMetrics
      */
     public abstract long nextDay(long instance, int n);
 
-
     /**
      * Moves the given instance backward to the previous (existing) day.
      *
@@ -686,7 +670,6 @@ public abstract class CalendarMetrics
      * @return A new instance.
      */
     public abstract long prevDay(long instance);
-
 
     /**
      * Moves the given instance backward by one or more days.
@@ -796,6 +779,13 @@ public abstract class CalendarMetrics
         // two CalendarMetrics equal when their classes and the week definition are the same
         return getClass() == obj.getClass() && minDaysInFirstWeek == ((CalendarMetrics) obj).minDaysInFirstWeek
                 && weekStart == ((CalendarMetrics) obj).weekStart;
+    }
+
+
+    @Override
+    public String toString()
+    {
+        return mName;
     }
 
 

--- a/src/main/java/org/dmfs/rfc5545/calendarmetrics/GregorianCalendarMetrics.java
+++ b/src/main/java/org/dmfs/rfc5545/calendarmetrics/GregorianCalendarMetrics.java
@@ -37,7 +37,7 @@ public class GregorianCalendarMetrics extends NoLeapMonthCalendarMetrics
         @Override
         public CalendarMetrics getCalendarMetrics(Weekday weekStart)
         {
-            return new GregorianCalendarMetrics(weekStart, 4);
+            return new GregorianCalendarMetrics(CALENDAR_SCALE_ALIAS, weekStart, 4);
         }
 
 
@@ -75,7 +75,21 @@ public class GregorianCalendarMetrics extends NoLeapMonthCalendarMetrics
      */
     public GregorianCalendarMetrics(Weekday weekStart, int minDaysInFirstWeek)
     {
-        super(weekStart, minDaysInFirstWeek);
+        super(CALENDAR_SCALE_ALIAS, weekStart, minDaysInFirstWeek);
+    }
+
+
+    /**
+     * Create calendar metrics for a Gregorian calendar with the given week numbering.
+     *
+     * @param weekStart
+     *         The first day of the week.
+     * @param minDaysInFirstWeek
+     *         The minimal number of days in the first week.
+     */
+    GregorianCalendarMetrics(String name, Weekday weekStart, int minDaysInFirstWeek)
+    {
+        super(name, weekStart, minDaysInFirstWeek);
     }
 
 

--- a/src/main/java/org/dmfs/rfc5545/calendarmetrics/IslamicCalendarMetrics.java
+++ b/src/main/java/org/dmfs/rfc5545/calendarmetrics/IslamicCalendarMetrics.java
@@ -33,7 +33,6 @@ public class IslamicCalendarMetrics extends NoLeapMonthCalendarMetrics
     public final static long DAYS_PER_CYCLE = 30 * 354 + 11;
     public final static long MILLIS_PER_DAY = 24 * 3600 * 1000;
 
-
     ;
     public final static long MILLIS_PER_CYCLE = DAYS_PER_CYCLE * MILLIS_PER_DAY;
     /**
@@ -68,6 +67,7 @@ public class IslamicCalendarMetrics extends NoLeapMonthCalendarMetrics
     private final int mLeapYearPatternIndex;
     private final boolean mCivil;
 
+
     /**
      * Create calendar metrics for an Islamic calendar with the given week numbering.
      *
@@ -76,9 +76,9 @@ public class IslamicCalendarMetrics extends NoLeapMonthCalendarMetrics
      * @param minDaysInFirstWeek
      *         The minimal number of days in the first week.
      */
-    public IslamicCalendarMetrics(Weekday weekStart, int minDaysInFirstWeek, LeapYearPattern leapYearPatternIndex, boolean civil)
+    public IslamicCalendarMetrics(String name, Weekday weekStart, int minDaysInFirstWeek, LeapYearPattern leapYearPatternIndex, boolean civil)
     {
-        super(weekStart, minDaysInFirstWeek);
+        super(name, weekStart, minDaysInFirstWeek);
         mLeapYearPatternIndex = leapYearPatternIndex.ordinal();
         mCivil = civil;
     }
@@ -406,7 +406,7 @@ public class IslamicCalendarMetrics extends NoLeapMonthCalendarMetrics
         @Override
         public CalendarMetrics getCalendarMetrics(Weekday weekStart)
         {
-            return new IslamicCalendarMetrics(weekStart, 4, mPattern, mCivil);
+            return new IslamicCalendarMetrics(mName, weekStart, 4, mPattern, mCivil);
         }
 
 

--- a/src/main/java/org/dmfs/rfc5545/calendarmetrics/JulianCalendarMetrics.java
+++ b/src/main/java/org/dmfs/rfc5545/calendarmetrics/JulianCalendarMetrics.java
@@ -40,7 +40,7 @@ public class JulianCalendarMetrics extends GregorianCalendarMetrics
         @Override
         public CalendarMetrics getCalendarMetrics(Weekday weekStart)
         {
-            return new JulianCalendarMetrics(weekStart, 4);
+            return new JulianCalendarMetrics(CALENDAR_SCALE_ALIAS, weekStart, 4);
         }
 
 
@@ -67,7 +67,21 @@ public class JulianCalendarMetrics extends GregorianCalendarMetrics
      */
     public JulianCalendarMetrics(Weekday weekStart, int minDaysInFirstWeek)
     {
-        super(weekStart, minDaysInFirstWeek);
+        super(CALENDAR_SCALE_ALIAS, weekStart, minDaysInFirstWeek);
+    }
+
+
+    /**
+     * Create calendar metrics for a Julian calendar with the given week numbering.
+     *
+     * @param weekStart
+     *         The first day of the week.
+     * @param minDaysInFirstWeek
+     *         The minimal number of days in the first week.
+     */
+    JulianCalendarMetrics(String name, Weekday weekStart, int minDaysInFirstWeek)
+    {
+        super(name, weekStart, minDaysInFirstWeek);
     }
 
 
@@ -127,7 +141,8 @@ public class JulianCalendarMetrics extends GregorianCalendarMetrics
         GregorianCalendarMetrics gregorianMetrics = mGregorianCalendarMetrics;
         if (gregorianMetrics == null)
         {
-            gregorianMetrics = mGregorianCalendarMetrics = new GregorianCalendarMetrics(weekStart, minDaysInFirstWeek);
+            gregorianMetrics = mGregorianCalendarMetrics = new GregorianCalendarMetrics(GregorianCalendarMetrics.CALENDAR_SCALE_ALIAS, weekStart,
+                    minDaysInFirstWeek);
         }
 
         // adjust day of month over- or under-run

--- a/src/main/java/org/dmfs/rfc5545/calendarmetrics/NoLeapMonthCalendarMetrics.java
+++ b/src/main/java/org/dmfs/rfc5545/calendarmetrics/NoLeapMonthCalendarMetrics.java
@@ -36,14 +36,16 @@ public abstract class NoLeapMonthCalendarMetrics extends CalendarMetrics
     /**
      * Create calendar metrics for a calendar without leap months with the given week numbering.
      *
+     * @param name
+     *         The Name of the Calendar Scale.
      * @param weekStart
      *         The first day of the week.
      * @param minDaysInFirstWeek
      *         The minimal number of days in the first week.
      */
-    public NoLeapMonthCalendarMetrics(Weekday weekStart, int minDaysInFirstWeek)
+    public NoLeapMonthCalendarMetrics(String name, Weekday weekStart, int minDaysInFirstWeek)
     {
-        super(weekStart, minDaysInFirstWeek);
+        super(name, weekStart, minDaysInFirstWeek);
     }
 
 

--- a/src/test/java/org/dmfs/rfc5545/DateTimeTest.java
+++ b/src/test/java/org/dmfs/rfc5545/DateTimeTest.java
@@ -102,7 +102,7 @@ public class DateTimeTest
     public void testDateTimeCalendarMetricsDateTime()
     {
         CalendarMetrics gregorian = new GregorianCalendarMetrics(Weekday.MO, 4);
-        CalendarMetrics islamic = new IslamicCalendarMetrics(Weekday.MO, 4, IslamicCalendarMetrics.LeapYearPattern.I, true);
+        CalendarMetrics islamic = new IslamicCalendarMetrics("", Weekday.MO, 4, IslamicCalendarMetrics.LeapYearPattern.I, true);
 
         DateTime allday = DateTime.parse(gregorian, null, "20151212");
         DateTime floating = DateTime.parse(gregorian, null, "20151212T130000");
@@ -139,7 +139,7 @@ public class DateTimeTest
     public void testDateTimeCalendarMetricsTimeZoneDateTime()
     {
         CalendarMetrics gregorian = new GregorianCalendarMetrics(Weekday.MO, 4);
-        CalendarMetrics islamic = new IslamicCalendarMetrics(Weekday.MO, 4, IslamicCalendarMetrics.LeapYearPattern.I, true);
+        CalendarMetrics islamic = new IslamicCalendarMetrics("", Weekday.MO, 4, IslamicCalendarMetrics.LeapYearPattern.I, true);
 
         DateTime allday = DateTime.parse(gregorian, null, "20151212");
         DateTime floating = DateTime.parse(gregorian, null, "20151212T130000");

--- a/src/test/java/org/dmfs/rfc5545/calendarmetrics/GregorianCalendarMetricsTest.java
+++ b/src/test/java/org/dmfs/rfc5545/calendarmetrics/GregorianCalendarMetricsTest.java
@@ -27,7 +27,9 @@ import java.util.GregorianCalendar;
 import java.util.Locale;
 import java.util.TimeZone;
 
+import static org.hamcrest.Matchers.hasToString;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 
 /**
@@ -804,4 +806,10 @@ public class GregorianCalendarMetricsTest
         }
     }
 
+
+    @Test
+    public void testToString()
+    {
+        assertThat(new GregorianCalendarMetrics(Weekday.MO, 4), hasToString("GREGORIAN"));
+    }
 }

--- a/src/test/java/org/dmfs/rfc5545/calendarmetrics/IslamicCalendarMetricsTest.java
+++ b/src/test/java/org/dmfs/rfc5545/calendarmetrics/IslamicCalendarMetricsTest.java
@@ -57,7 +57,6 @@ public class IslamicCalendarMetricsTest
         initMaps4();
     }
 
-
     /**
      * Add a number of instances created with <a href="http://www.staff.science.uu.nl/~gent0113/islam/islam_tabcal.htm">Islamic-Western Calendar Converter</a>
      */
@@ -3660,7 +3659,7 @@ public class IslamicCalendarMetricsTest
     @Test
     public void testGetPackedMonthOfYearDay()
     {
-        CalendarMetrics testMetrics = new IslamicCalendarMetrics(Weekday.MO, 4, LeapYearPattern.II, true);
+        CalendarMetrics testMetrics = new IslamicCalendarMetrics("", Weekday.MO, 4, LeapYearPattern.II, true);
         for (int year = 1; year < 3000; ++year)
         {
             for (int month = 0; month < 12; ++month)
@@ -3750,7 +3749,7 @@ public class IslamicCalendarMetricsTest
     public void testGetDayOfWeekIntIntInt()
     {
         // TODO: add more tests, at least one for each year in the 30 year cycle
-        CalendarMetrics testMetrics = new IslamicCalendarMetrics(Weekday.MO, 4, LeapYearPattern.II, true);
+        CalendarMetrics testMetrics = new IslamicCalendarMetrics("", Weekday.MO, 4, LeapYearPattern.II, true);
         assertEquals(Weekday.FR.ordinal(), testMetrics.getDayOfWeek(1, 0, 1));
         assertEquals(Weekday.FR.ordinal(), testMetrics.getDayOfWeek(999, 1, 2));
         assertEquals(Weekday.TU.ordinal(), testMetrics.getDayOfWeek(1100, 2, 12));
@@ -3760,7 +3759,7 @@ public class IslamicCalendarMetricsTest
         assertEquals(Weekday.TH.ordinal(), testMetrics.getDayOfWeek(1499, 9, 25));
 
         // TODO: add more tests, at least one for each year in the 30 year cycle
-        testMetrics = new IslamicCalendarMetrics(Weekday.MO, 4, LeapYearPattern.II, false);
+        testMetrics = new IslamicCalendarMetrics("", Weekday.MO, 4, LeapYearPattern.II, false);
         assertEquals(Weekday.FR.ordinal(), testMetrics.getDayOfWeek(1, 0, 1));
         assertEquals(Weekday.FR.ordinal(), testMetrics.getDayOfWeek(999, 1, 2));
         assertEquals(Weekday.TU.ordinal(), testMetrics.getDayOfWeek(1100, 2, 12));
@@ -3791,25 +3790,25 @@ public class IslamicCalendarMetricsTest
     @Test
     public void testGetWeekDayOfFirstYearDay()
     {
-        CalendarMetrics testMetrics = new IslamicCalendarMetrics(Weekday.MO, 4, LeapYearPattern.I, true);
+        CalendarMetrics testMetrics = new IslamicCalendarMetrics("", Weekday.MO, 4, LeapYearPattern.I, true);
         for (int year = 1; year < 3000; ++year)
         {
             assertEquals(testMetrics.getDayOfWeek(year, 0, 1), testMetrics.getWeekDayOfFirstYearDay(year));
         }
 
-        testMetrics = new IslamicCalendarMetrics(Weekday.MO, 4, LeapYearPattern.II, true);
+        testMetrics = new IslamicCalendarMetrics("", Weekday.MO, 4, LeapYearPattern.II, true);
         for (int year = 1; year < 3000; ++year)
         {
             assertEquals(testMetrics.getDayOfWeek(year, 0, 1), testMetrics.getWeekDayOfFirstYearDay(year));
         }
 
-        testMetrics = new IslamicCalendarMetrics(Weekday.MO, 4, LeapYearPattern.III, true);
+        testMetrics = new IslamicCalendarMetrics("", Weekday.MO, 4, LeapYearPattern.III, true);
         for (int year = 1; year < 3000; ++year)
         {
             assertEquals(testMetrics.getDayOfWeek(year, 0, 1), testMetrics.getWeekDayOfFirstYearDay(year));
         }
 
-        testMetrics = new IslamicCalendarMetrics(Weekday.MO, 4, LeapYearPattern.IV, true);
+        testMetrics = new IslamicCalendarMetrics("", Weekday.MO, 4, LeapYearPattern.IV, true);
         for (int year = 1; year < 3000; ++year)
         {
             assertEquals(testMetrics.getDayOfWeek(year, 0, 1), testMetrics.getWeekDayOfFirstYearDay(year));
@@ -3844,7 +3843,7 @@ public class IslamicCalendarMetricsTest
             {
                 for (int civil = 0; civil < 2; ++civil)
                 {
-                    IslamicCalendarMetrics calendar = new IslamicCalendarMetrics(Weekday.MO, 0, LeapYearPattern.values()[pattern], civil == 1);
+                    IslamicCalendarMetrics calendar = new IslamicCalendarMetrics("", Weekday.MO, 0, LeapYearPattern.values()[pattern], civil == 1);
                     {
                         for (long gregorian : DATE_MAPS[pattern][civil].keySet())
                         {
@@ -3880,7 +3879,7 @@ public class IslamicCalendarMetricsTest
             {
                 for (int civil = 0; civil < 2; ++civil)
                 {
-                    IslamicCalendarMetrics calendar = new IslamicCalendarMetrics(Weekday.MO, 0, LeapYearPattern.values()[pattern], civil == 1);
+                    IslamicCalendarMetrics calendar = new IslamicCalendarMetrics("", Weekday.MO, 0, LeapYearPattern.values()[pattern], civil == 1);
                     {
                         for (long gregorian : DATE_MAPS[pattern][civil].keySet())
                         {
@@ -3900,35 +3899,35 @@ public class IslamicCalendarMetricsTest
     @Test
     public void testIslamicToGregorian()
     {
-        IslamicCalendarMetrics islamicCalendar = new IslamicCalendarMetrics(Weekday.MO, 0, LeapYearPattern.I, true);
+        IslamicCalendarMetrics islamicCalendar = new IslamicCalendarMetrics("", Weekday.MO, 0, LeapYearPattern.I, true);
         assertEquals(Instance.make(1970, 0, 1, 0, 0, 0, 0), islamicCalendar.toGregorian(Instance.make(1389, 9, 22, 0, 0, 0, 0)));
 
-        islamicCalendar = new IslamicCalendarMetrics(Weekday.MO, 0, LeapYearPattern.I, false);
+        islamicCalendar = new IslamicCalendarMetrics("", Weekday.MO, 0, LeapYearPattern.I, false);
         assertEquals(Instance.make(1970, 0, 1, 0, 0, 0, 0), islamicCalendar.toGregorian(Instance.make(1389, 9, 23, 0, 0, 0, 0)));
 
-        islamicCalendar = new IslamicCalendarMetrics(Weekday.MO, 0, LeapYearPattern.II, true);
+        islamicCalendar = new IslamicCalendarMetrics("", Weekday.MO, 0, LeapYearPattern.II, true);
         assertEquals(Instance.make(1970, 0, 1, 0, 0, 0, 0), islamicCalendar.toGregorian(Instance.make(1389, 9, 22, 0, 0, 0, 0)));
 
-        islamicCalendar = new IslamicCalendarMetrics(Weekday.MO, 0, LeapYearPattern.II, false);
+        islamicCalendar = new IslamicCalendarMetrics("", Weekday.MO, 0, LeapYearPattern.II, false);
         assertEquals(Instance.make(1970, 0, 1, 0, 0, 0, 0), islamicCalendar.toGregorian(Instance.make(1389, 9, 23, 0, 0, 0, 0)));
 
-        islamicCalendar = new IslamicCalendarMetrics(Weekday.MO, 0, LeapYearPattern.III, true);
+        islamicCalendar = new IslamicCalendarMetrics("", Weekday.MO, 0, LeapYearPattern.III, true);
         assertEquals(Instance.make(1970, 0, 1, 0, 0, 0, 0), islamicCalendar.toGregorian(Instance.make(1389, 9, 22, 0, 0, 0, 0)));
 
-        islamicCalendar = new IslamicCalendarMetrics(Weekday.MO, 0, LeapYearPattern.III, false);
+        islamicCalendar = new IslamicCalendarMetrics("", Weekday.MO, 0, LeapYearPattern.III, false);
         assertEquals(Instance.make(1970, 0, 1, 0, 0, 0, 0), islamicCalendar.toGregorian(Instance.make(1389, 9, 23, 0, 0, 0, 0)));
 
-        islamicCalendar = new IslamicCalendarMetrics(Weekday.MO, 0, LeapYearPattern.IV, true);
+        islamicCalendar = new IslamicCalendarMetrics("", Weekday.MO, 0, LeapYearPattern.IV, true);
         assertEquals(Instance.make(1970, 0, 1, 0, 0, 0, 0), islamicCalendar.toGregorian(Instance.make(1389, 9, 22, 0, 0, 0, 0)));
 
-        islamicCalendar = new IslamicCalendarMetrics(Weekday.MO, 0, LeapYearPattern.IV, false);
+        islamicCalendar = new IslamicCalendarMetrics("", Weekday.MO, 0, LeapYearPattern.IV, false);
         assertEquals(Instance.make(1970, 0, 1, 0, 0, 0, 0), islamicCalendar.toGregorian(Instance.make(1389, 9, 23, 0, 0, 0, 0)));
 
         for (int pattern = 0; pattern < 4; ++pattern)
         {
             for (int civil = 0; civil < 2; ++civil)
             {
-                IslamicCalendarMetrics calendar = new IslamicCalendarMetrics(Weekday.MO, 0, LeapYearPattern.values()[pattern], civil == 1);
+                IslamicCalendarMetrics calendar = new IslamicCalendarMetrics("", Weekday.MO, 0, LeapYearPattern.values()[pattern], civil == 1);
                 {
                     for (long gregorian : DATE_MAPS[pattern][civil].keySet())
                     {

--- a/src/test/java/org/dmfs/rfc5545/calendarmetrics/JulianCalendarMetricsTest.java
+++ b/src/test/java/org/dmfs/rfc5545/calendarmetrics/JulianCalendarMetricsTest.java
@@ -28,7 +28,9 @@ import java.util.GregorianCalendar;
 import java.util.Locale;
 import java.util.TimeZone;
 
+import static org.hamcrest.Matchers.hasToString;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 
 /**
@@ -751,4 +753,10 @@ public class JulianCalendarMetricsTest
         }
     }
 
+
+    @Test
+    public void testToString()
+    {
+        assertThat(new JulianCalendarMetrics(Weekday.MO, 4), hasToString("JULIAN"));
+    }
 }


### PR DESCRIPTION
Make sure CalendarMetrics return their name in toString.